### PR TITLE
Fix for tags not properly unescaped

### DIFF
--- a/scripts/ranbooru.py
+++ b/scripts/ranbooru.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+import html
 import random
 import requests
 import modules.scripts as scripts
@@ -842,7 +843,7 @@ class Script(scripts.Script):
             new_prompts = []
             # Cleaning Tags
             for prompt in prompts:
-                prompt_tags = [tag for tag in prompt.split(',') if tag.strip() not in bad_tags]
+                prompt_tags = [tag for tag in html.unescape(prompt).split(',') if tag.strip() not in bad_tags]
                 for bad_tag in bad_tags:
                     if '*' in bad_tag:
                         prompt_tags = [tag for tag in prompt_tags if bad_tag.replace('*', '') not in tag]


### PR DESCRIPTION
Fixes #40 

Simple, basically a 1-line fix.
Resolves the HTML escaping as described in #40, which seems to be an issue with some of the booru, including Gelbooru.

Tested on all booru options using `hands_on_another's_head`, and issue was resolved on each affected option with no adverse effects. 
konachan and yand.re throw error `ValueError: Sample larger than population or is negative`, but appears unrelated (error occurs even without these changes) and thus out of scope for the PR.

Example result on Gelbooru (tag is properly included as seen at the bottom)
![Screenshot 2025-04-13 175149](https://github.com/user-attachments/assets/56cbc5e4-8679-408c-9848-775fcd011ddd)

Example of current behavior (after the &, the remaining prompt will be lost)
![2](https://github.com/user-attachments/assets/434b838f-f219-4305-ab16-bb8e6b334b91)
